### PR TITLE
add a workflow to keep other scheduled workflows alive

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,42 @@
+name: Keep scheduled workflows alive
+
+on:
+  schedule:
+    - cron: "16 07 10 * *"
+  workflow_dispatch:
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: 'true'
+      - name: Create and push a commit
+        env:
+          GIT_CONFIG_PARAMETERS: "'user.name=CI' 'user.email=ci@github'"
+        run: |
+          mkdir -p .github/cached
+          file='.github/cached/keepalive.txt'
+          date > $file
+          git add "$file"
+          git commit -m "workflow keepalive" &&
+          if test "$GITHUB_ACTOR" = nektos/act
+          then
+            echo "Would push commit:"
+            git -P show --stat
+          else
+            git push origin HEAD </dev/null || {
+              for i in 1 2 3 4 5
+              do
+                # In case of concurrent pushes, let's pull and push
+                git pull origin $GITHUB_REF </dev/null || exit 1
+                git push origin HEAD </dev/null && exit 0
+              done
+              exit 1
+            }
+          fi


### PR DESCRIPTION
GitHub disables scheduled workflows after 60 days of inactivity on a repository. 
![Screenshot of GitHub message about disabled workflow](https://user-images.githubusercontent.com/6178234/198974277-467261ea-5ceb-4855-a16c-a521bb82d5fb.png)

This has caused us to miss the release of `less` 608.

Work around this behaviour by adding a scheduled workflow that creates a small commit once per month.